### PR TITLE
Create MelodyQuest infrastructure monorepo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Application URLs
+APP_URL=http://localhost
+API_URL=http://localhost/api
+REALTIME_URL=http://localhost/socket.io
+
+# Database configuration
+DB_HOST=mysql
+DB_PORT=3306
+DB_DATABASE=melodyquest
+DB_USERNAME=melodyquest
+DB_PASSWORD=secret
+DB_ROOT_PASSWORD=secretroot
+
+# Redis configuration
+REDIS_HOST=redis
+REDIS_PORT=6379

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.env
+node_modules
+vendor
+web_build
+web_node_modules
+realtime_node_modules
+mysql_data
+redis_data
+.idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# MelodyQuest-Codex
-Projet MelodyQuest réalisé uniquement par ChatGPT et Codex
+# MelodyQuest Monorepo
+
+This repository contains the MelodyQuest mono-repo including the web client, realtime gateway, and PHP API.
+
+## Getting started
+
+1. Copy `.env.example` to `.env` and adjust credentials if necessary.
+2. Build and start the stack:
+
+```bash
+docker compose up -d --build
+```
+
+The initial build installs dependencies and prepares the static web assets that will be served by Nginx.
+
+## Services
+
+Once the stack is running, access the application via [http://localhost](http://localhost).
+
+Exposed services:
+
+- **Nginx** – http://localhost (serves the web SPA and proxies `/api` and `/socket.io`).
+- **PHP API** – proxied via `/api` path (FastCGI to PHP-FPM).
+- **Realtime Gateway** – proxied via `/socket.io` (Socket.IO over WebSocket/HTTP).
+- **MySQL** – exposed on port `3306` for local development tooling.
+- **Redis** – internal cache/pub-sub for realtime features.
+
+Database schema initialization scripts live in `infra/db-init` and Redis configuration is stored under `infra/redis`.

--- a/apps/api-php/Dockerfile
+++ b/apps/api-php/Dockerfile
@@ -1,0 +1,27 @@
+FROM php:8.3-fpm-alpine
+
+RUN apk add --no-cache \
+    icu-dev \
+    libzip-dev \
+    oniguruma-dev \
+    git \
+    unzip \
+    curl \
+    bash \
+    mysql-client \
+    $PHPIZE_DEPS \
+ && docker-php-ext-install pdo_mysql intl mbstring \
+ && apk del $PHPIZE_DEPS
+
+WORKDIR /var/www/api
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+COPY composer.json composer.lock* ./
+RUN composer install --no-dev --prefer-dist --no-interaction
+
+COPY . .
+
+RUN composer dump-autoload --optimize
+
+CMD ["php-fpm"]

--- a/apps/api-php/composer.json
+++ b/apps/api-php/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "melodyquest/api",
+    "description": "MelodyQuest API service built with Slim Framework",
+    "type": "project",
+    "require": {
+        "php": "^8.3",
+        "slim/slim": "^4.12",
+        "slim/psr7": "^1.6",
+        "nyholm/psr7": "^1.8",
+        "vlucas/phpdotenv": "^5.6",
+        "illuminate/database": "^11.0",
+        "respect/validation": "^2.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "MelodyQuest\\Api\\": "src/"
+        }
+    },
+    "scripts": {
+        "start": "php -S 0.0.0.0:8080 -t public"
+    },
+    "minimum-stability": "stable",
+    "license": "MIT"
+}

--- a/apps/api-php/public/index.php
+++ b/apps/api-php/public/index.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$app = AppFactory::create();
+
+require __DIR__ . '/../src/bootstrap.php';
+
+$app->get('/api/health', function (Request $request, Response $response): Response {
+    $payload = json_encode(['status' => 'ok'], JSON_PRETTY_PRINT);
+    $response->getBody()->write($payload ?: '');
+    return $response->withHeader('Content-Type', 'application/json');
+});
+
+$app->map(['GET', 'POST', 'PUT', 'DELETE'], '/api/routes-placeholder', function (Request $request, Response $response): Response {
+    $response->getBody()->write(json_encode([
+        'message' => 'Define your routes here',
+    ], JSON_PRETTY_PRINT) ?: '');
+    return $response->withHeader('Content-Type', 'application/json');
+});
+
+$app->run();

--- a/apps/api-php/src/bootstrap.php
+++ b/apps/api-php/src/bootstrap.php
@@ -1,0 +1,29 @@
+<?php
+
+use Dotenv\Dotenv;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Container\Container;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$dotenv = Dotenv::createImmutable(__DIR__ . '/..');
+$dotenv->safeLoad();
+
+$capsule = new Capsule();
+$capsule->addConnection([
+    'driver' => 'mysql',
+    'host' => $_ENV['DB_HOST'] ?? 'mysql',
+    'port' => (int) ($_ENV['DB_PORT'] ?? 3306),
+    'database' => $_ENV['DB_DATABASE'] ?? 'melodyquest',
+    'username' => $_ENV['DB_USERNAME'] ?? 'melodyquest',
+    'password' => $_ENV['DB_PASSWORD'] ?? 'secret',
+    'charset' => 'utf16',
+    'collation' => 'utf16_general_ci',
+    'prefix' => '',
+]);
+$capsule->setEventDispatcher(new Dispatcher(new Container()));
+$capsule->setAsGlobal();
+$capsule->bootEloquent();
+
+return $capsule;

--- a/apps/realtime-node/index.js
+++ b/apps/realtime-node/index.js
@@ -1,0 +1,80 @@
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import Redis from 'ioredis';
+import { z } from 'zod';
+
+const PORT = process.env.PORT || 3000;
+const redisHost = process.env.REDIS_HOST || 'redis';
+const redisPort = Number(process.env.REDIS_PORT || 6379);
+
+const httpServer = createServer();
+
+const io = new Server(httpServer, {
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST']
+  }
+});
+
+const redis = new Redis({ host: redisHost, port: redisPort });
+const pub = new Redis({ host: redisHost, port: redisPort });
+
+const gameNamespace = io.of('/game');
+
+const joinSchema = z.object({
+  gameId: z.string().min(1),
+  playerId: z.string().min(1)
+});
+
+gameNamespace.on('connection', (socket) => {
+  socket.on('join', (payload) => {
+    const result = joinSchema.safeParse(payload);
+    if (!result.success) {
+      socket.emit('error', { message: 'Invalid join payload' });
+      return;
+    }
+
+    const { gameId, playerId } = result.data;
+    const room = `game:${gameId}`;
+    socket.join(room);
+    socket.emit('joined', { gameId, playerId });
+  });
+
+  socket.on('leave', (payload) => {
+    const result = joinSchema.safeParse(payload);
+    if (!result.success) {
+      return;
+    }
+    const room = `game:${result.data.gameId}`;
+    socket.leave(room);
+  });
+
+  socket.on('broadcast', (payload) => {
+    const message = typeof payload === 'object' ? payload : { message: String(payload) };
+    const channel = 'melodyquest:events';
+    pub.publish(channel, JSON.stringify(message));
+  });
+});
+
+redis.subscribe('melodyquest:events', (err) => {
+  if (err) {
+    console.error('Redis subscription error', err);
+  }
+});
+
+redis.on('message', (channel, message) => {
+  if (channel !== 'melodyquest:events') {
+    return;
+  }
+  let payload = message;
+  try {
+    payload = JSON.parse(message);
+  } catch (error) {
+    // ignore json parse errors
+  }
+  gameNamespace.emit('event', payload);
+});
+
+httpServer.listen(PORT, () => {
+  console.log(`Realtime server listening on port ${PORT}`);
+});

--- a/apps/realtime-node/package.json
+++ b/apps/realtime-node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "melodyquest-realtime",
+  "version": "0.1.0",
+  "description": "MelodyQuest realtime gateway using Socket.IO",
+  "type": "module",
+  "scripts": {
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "ioredis": "^5.4.1",
+    "socket.io": "^4.7.5",
+    "zod": "^3.22.4"
+  }
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MelodyQuest</title>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "melodyquest-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,29 @@
+function App() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center text-center gap-6">
+      <h1 className="text-5xl font-bold tracking-tight">MelodyQuest</h1>
+      <p className="max-w-xl text-lg text-slate-300">
+        Embark on a musical adventure. This placeholder interface will soon guide players through quests,
+        challenges, and realtime battles synchronized with the MelodyQuest universe.
+      </p>
+      <div className="flex gap-4">
+        <a
+          className="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 transition"
+          href="/api/health"
+          target="_blank"
+          rel="noreferrer"
+        >
+          API Health
+        </a>
+        <a
+          className="px-4 py-2 rounded border border-indigo-400 text-indigo-200 hover:bg-indigo-500/10 transition"
+          href="#"
+        >
+          Coming Soon
+        </a>
+      </div>
+    </main>
+  );
+}
+
+export default App;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+body {
+  margin: 0;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 5173
+  },
+  build: {
+    outDir: 'dist'
+  }
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,140 @@
+version: '3.9'
+
+services:
+  nginx:
+    image: nginx:1.25-alpine
+    depends_on:
+      web:
+        condition: service_completed_successfully
+      php:
+        condition: service_healthy
+      realtime:
+        condition: service_started
+    ports:
+      - "80:80"
+    volumes:
+      - web_build:/usr/share/nginx/html:ro
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      - melodyquest_net
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  web:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - ./apps/web:/app
+      - web_node_modules:/app/node_modules
+      - web_build:/app/dist
+    command: sh -c "npm install && npm run build"
+    environment:
+      - NODE_ENV=production
+    networks:
+      - melodyquest_net
+    healthcheck:
+      test: ["CMD", "node", "-e", "process.exit(0)"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  php:
+    build:
+      context: ./apps/api-php
+      dockerfile: Dockerfile
+    volumes:
+      - ./apps/api-php:/var/www/api
+      - /var/www/api/vendor
+    environment:
+      - APP_ENV=development
+      - DB_HOST=mysql
+      - DB_PORT=3306
+      - DB_DATABASE=${DB_DATABASE}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+    networks:
+      melodyquest_net:
+        aliases:
+          - php-fpm
+    depends_on:
+      mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "php", "-m"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  mysql:
+    image: mysql:8.3
+    environment:
+      - MYSQL_ROOT_PASSWORD=${DB_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${DB_DATABASE}
+      - MYSQL_USER=${DB_USERNAME}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./infra/db-init:/docker-entrypoint-initdb.d
+    command: ["mysqld", "--character-set-server=utf16", "--collation-server=utf16_general_ci"]
+    networks:
+      - melodyquest_net
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    volumes:
+      - redis_data:/data
+      - ./infra/redis/redis.conf:/usr/local/etc/redis/redis.conf:ro
+    networks:
+      - melodyquest_net
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  realtime:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - ./apps/realtime-node:/app
+      - realtime_node_modules:/app/node_modules
+    command: sh -c "npm install && npm run dev"
+    environment:
+      - NODE_ENV=development
+      - PORT=3000
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    ports:
+      - "3000:3000"
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - melodyquest_net
+    healthcheck:
+      test: ["CMD", "node", "-e", "process.exit(0)"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+networks:
+  melodyquest_net:
+    driver: bridge
+
+volumes:
+  mysql_data:
+  redis_data:
+  web_node_modules:
+  realtime_node_modules:
+  web_build:

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,53 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api {
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
+
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME /var/www/api/public/index.php;
+        fastcgi_param SCRIPT_NAME /index.php;
+        fastcgi_param DOCUMENT_ROOT /var/www/api/public;
+        fastcgi_param PATH_INFO $uri;
+        fastcgi_param REQUEST_URI $request_uri;
+        fastcgi_pass php-fpm:9000;
+    }
+
+    location /socket.io/ {
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
+
+        if ($request_method = OPTIONS) {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
+            return 204;
+        }
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_pass http://realtime:3000/socket.io/;
+    }
+}

--- a/infra/db-init/01_schema.sql
+++ b/infra/db-init/01_schema.sql
@@ -1,0 +1,5 @@
+CREATE DATABASE IF NOT EXISTS melodyquest
+  CHARACTER SET utf16
+  COLLATE utf16_general_ci;
+
+-- TODO: Define tables for MelodyQuest schema.

--- a/infra/redis/redis.conf
+++ b/infra/redis/redis.conf
@@ -1,0 +1,4 @@
+bind 0.0.0.0
+protected-mode no
+port 6379
+appendonly yes


### PR DESCRIPTION
## Summary
- scaffold MelodyQuest mono-repo with PHP API, realtime Node service, and React web app
- configure Docker Compose stack with MySQL, Redis, and Nginx reverse proxy for API and Socket.IO
- add initial database schema seed, environment template, and development documentation

## Testing
- not run (infrastructure only)

------
https://chatgpt.com/codex/tasks/task_e_68e398735610833090d30b2439c22b99