### PR TITLE
Add realtime Socket.IO gateway service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Application URLs
+APP_URL=http://localhost
+API_URL=http://localhost/api
+REALTIME_URL=http://localhost/socket.io
+
+# Database configuration
+DB_HOST=mysql
+DB_PORT=3306
+DB_DATABASE=melodyquest
+DB_USERNAME=melodyquest
+DB_PASSWORD=secret
+DB_ROOT_PASSWORD=secretroot
+
+# Redis configuration
+REDIS_HOST=redis
+REDIS_PORT=6379

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.env
+node_modules
+vendor
+web_build
+web_node_modules
+realtime_node_modules
+mysql_data
+redis_data
+.idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# MelodyQuest-Codex
-Projet MelodyQuest réalisé uniquement par ChatGPT et Codex
+# MelodyQuest Monorepo
+
+This repository contains the MelodyQuest mono-repo including the web client, realtime gateway, and PHP API.
+
+## Getting started
+
+1. Copy `.env.example` to `.env` and adjust credentials if necessary.
+2. Build and start the stack:
+
+```bash
+docker compose up -d --build
+```
+
+The initial build installs dependencies and prepares the static web assets that will be served by Nginx.
+
+## Services
+
+Once the stack is running, access the application via [http://localhost](http://localhost).
+
+Exposed services:
+
+- **Nginx** – http://localhost (serves the web SPA and proxies `/api` and `/socket.io`).
+- **PHP API** – proxied via `/api` path (FastCGI to PHP-FPM).
+- **Realtime Gateway** – proxied via `/socket.io` (Socket.IO over WebSocket/HTTP).
+- **MySQL** – exposed on port `3306` for local development tooling.
+- **Redis** – internal cache/pub-sub for realtime features.
+
+Database schema initialization scripts live in `infra/db-init` and Redis configuration is stored under `infra/redis`.

--- a/apps/api-php/Dockerfile
+++ b/apps/api-php/Dockerfile
@@ -1,0 +1,27 @@
+FROM php:8.3-fpm-alpine
+
+RUN apk add --no-cache \
+    icu-dev \
+    libzip-dev \
+    oniguruma-dev \
+    git \
+    unzip \
+    curl \
+    bash \
+    mysql-client \
+    $PHPIZE_DEPS \
+ && docker-php-ext-install pdo_mysql intl mbstring \
+ && apk del $PHPIZE_DEPS
+
+WORKDIR /var/www/api
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+COPY composer.json composer.lock* ./
+RUN composer install --no-dev --prefer-dist --no-interaction
+
+COPY . .
+
+RUN composer dump-autoload --optimize
+
+CMD ["php-fpm"]

--- a/apps/api-php/README.md
+++ b/apps/api-php/README.md
@@ -1,0 +1,115 @@
+# MelodyQuest API
+
+This service exposes the REST API for MelodyQuest using Slim 4 and Eloquent. It expects the infrastructure defined in the repository (MySQL, Redis, Nginx, realtime gateway) to be running through Docker Compose.
+
+## Environment variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `APP_ENV` | Runtime environment (`development` enables permissive CORS and verbose errors). | `development` |
+| `ADMIN_TOKEN` | Shared secret required for the administrative endpoints. | `changeme` |
+| `DB_HOST` | MySQL host name. | `mysql` |
+| `DB_PORT` | MySQL port. | `3306` |
+| `DB_DATABASE` | MySQL database name. | `melodyquest` |
+| `DB_USERNAME` | MySQL user. | `root` |
+| `DB_PASSWORD` | MySQL password. | `secret` |
+| `REDIS_HOST` | Redis host. | `redis` |
+| `REDIS_PORT` | Redis port. | `6379` |
+| `RATE_LIMIT_PER_MIN` | Per-IP request limit per minute. | `60` |
+| `ALLOWED_ORIGINS` | Comma-separated list of allowed origins when `APP_ENV` is not `development`. | `*` |
+
+Copy `.env.example` from the repository root to `.env` and adjust the values if needed before launching Docker Compose.
+
+## Running locally
+
+The Docker Compose stack already runs composer install and boots PHP-FPM. From the repository root, start everything with:
+
+```bash
+docker compose up -d --build
+```
+
+The API is exposed through Nginx at <http://localhost/api>. Health can be checked with:
+
+```bash
+curl http://localhost/api/health
+```
+
+## Response format
+
+All endpoints return JSON payloads with the following envelope:
+
+- Success: `{ "ok": true, "data": <payload> }`
+- Error: `{ "ok": false, "error": { "code": "SOME_CODE", "message": "...", "details": [...] } }`
+
+## Key endpoints
+
+### Health
+
+```bash
+curl http://localhost/api/health
+```
+
+### Users
+
+Create or fetch a user:
+
+```bash
+curl -X POST http://localhost/api/users \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"PlayerOne"}'
+```
+
+### Admin categories (requires `X-Admin-Token` header)
+
+```bash
+curl -X POST http://localhost/api/admin/categories \
+  -H 'Content-Type: application/json' \
+  -H 'X-Admin-Token: changeme' \
+  -d '{"name":"Pop"}'
+```
+
+### Admin tracks
+
+```bash
+curl -X POST http://localhost/api/admin/tracks \
+  -H 'Content-Type: application/json' \
+  -H 'X-Admin-Token: changeme' \
+  -d '{
+        "youtube_url": "https://youtu.be/dQw4w9WgXcQ",
+        "category_id": 1,
+        "title": "Never Gonna Give You Up",
+        "answers": ["Rick Astley", "Never Gonna Give You Up"]
+      }'
+```
+
+### Games
+
+Create a game:
+
+```bash
+curl -X POST http://localhost/api/games \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "host_user_id": 1,
+        "round_count": 10,
+        "category_ids": [1,2]
+      }'
+```
+
+Join a game:
+
+```bash
+curl -X POST http://localhost/api/games/1/join \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id":2}'
+```
+
+Submit a guess:
+
+```bash
+curl -X POST http://localhost/api/rounds/1/guess \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id":2,"guess_text":"Never Gonna Give You Up"}'
+```
+
+Additional endpoints for starting games, advancing rounds, and retrieving state follow the same JSON conventions. Refer to `PlayerRoutes.php` and `AdminRoutes.php` for the complete list.

--- a/apps/api-php/bootstrap/app.php
+++ b/apps/api-php/bootstrap/app.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use MelodyQuest\Api\Config;
+use MelodyQuest\Api\Database;
+use MelodyQuest\Api\Middleware\AdminAuthMiddleware;
+use MelodyQuest\Api\Middleware\CorsMiddleware;
+use MelodyQuest\Api\Middleware\ErrorHandler;
+use MelodyQuest\Api\Middleware\JsonBodyParser;
+use MelodyQuest\Api\Middleware\RateLimitMiddleware;
+use MelodyQuest\Api\RedisBus;
+use MelodyQuest\Api\Routes\AdminRoutes;
+use MelodyQuest\Api\Routes\HealthRoutes;
+use MelodyQuest\Api\Routes\PlayerRoutes;
+use MelodyQuest\Api\Services\GameService;
+use MelodyQuest\Api\Services\GuessService;
+use MelodyQuest\Api\Services\TrackService;
+use Slim\Factory\AppFactory;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+Config::load(dirname(__DIR__, 2));
+Database::boot();
+$redisBus = RedisBus::create();
+
+$app = AppFactory::create();
+$app->addRoutingMiddleware();
+
+$errorMiddleware = $app->addErrorMiddleware(Config::isDevelopment(), true, true);
+$errorMiddleware->setDefaultErrorHandler(new ErrorHandler($app->getResponseFactory()));
+
+$app->add(new CorsMiddleware($app->getResponseFactory(), Config::allowedOrigins(), Config::isDevelopment()));
+$app->add(new RateLimitMiddleware($redisBus->client(), Config::rateLimitPerMinute(), $app->getResponseFactory()));
+$app->add(new JsonBodyParser($app->getResponseFactory()));
+
+$trackService = new TrackService();
+$gameService = new GameService($redisBus);
+$guessService = new GuessService($redisBus);
+$adminMiddleware = new AdminAuthMiddleware(Config::adminToken(), $app->getResponseFactory());
+
+HealthRoutes::register($app);
+AdminRoutes::register($app, $trackService, $adminMiddleware);
+PlayerRoutes::register($app, $gameService, $guessService);
+
+return $app;

--- a/apps/api-php/composer.json
+++ b/apps/api-php/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "melodyquest/api",
+    "description": "MelodyQuest API service built with Slim Framework",
+    "type": "project",
+    "require": {
+        "php": "^8.3",
+        "slim/slim": "^4.12",
+        "slim/psr7": "^1.6",
+        "vlucas/phpdotenv": "^5.6",
+        "illuminate/database": "^11.0",
+        "respect/validation": "^2.2",
+        "predis/predis": "^2.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "MelodyQuest\\Api\\": "src/"
+        }
+    },
+    "scripts": {
+        "start": "php -S 0.0.0.0:8080 -t public"
+    },
+    "minimum-stability": "stable",
+    "license": "MIT"
+}

--- a/apps/api-php/public/index.php
+++ b/apps/api-php/public/index.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+$app = require __DIR__ . '/../bootstrap/app.php';
+
+$app->run();

--- a/apps/api-php/src/Config.php
+++ b/apps/api-php/src/Config.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api;
+
+use Dotenv\Dotenv;
+
+class Config
+{
+    private static bool $loaded = false;
+
+    public static function load(?string $basePath = null): void
+    {
+        if (self::$loaded) {
+            return;
+        }
+
+        $paths = array_unique(array_filter([
+            $basePath,
+            dirname(__DIR__, 3),
+            dirname(__DIR__, 2),
+            dirname(__DIR__),
+        ]));
+
+        foreach ($paths as $path) {
+            if (!is_dir($path)) {
+                continue;
+            }
+
+            $envFile = $path . DIRECTORY_SEPARATOR . '.env';
+            if (is_file($envFile)) {
+                Dotenv::createImmutable($path)->safeLoad();
+            }
+        }
+
+        self::$loaded = true;
+    }
+
+    public static function env(string $key, mixed $default = null): mixed
+    {
+        return $_ENV[$key] ?? $_SERVER[$key] ?? $default;
+    }
+
+    public static function envInt(string $key, int $default): int
+    {
+        return (int) (self::env($key, $default));
+    }
+
+    public static function envBool(string $key, bool $default = false): bool
+    {
+        $value = self::env($key);
+        if ($value === null) {
+            return $default;
+        }
+
+        return in_array(strtolower((string) $value), ['1', 'true', 'yes', 'on'], true);
+    }
+
+    public static function allowedOrigins(): array
+    {
+        $origins = self::env('ALLOWED_ORIGINS', '*');
+        if ($origins === '*') {
+            return ['*'];
+        }
+
+        return array_values(array_filter(array_map('trim', explode(',', (string) $origins))));
+    }
+
+    public static function isDevelopment(): bool
+    {
+        return strtolower((string) self::env('APP_ENV', 'production')) === 'development';
+    }
+
+    public static function adminToken(): string
+    {
+        return (string) self::env('ADMIN_TOKEN', 'changeme');
+    }
+
+    public static function rateLimitPerMinute(): int
+    {
+        return self::envInt('RATE_LIMIT_PER_MIN', 60);
+    }
+}

--- a/apps/api-php/src/Database.php
+++ b/apps/api-php/src/Database.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api;
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+class Database
+{
+    private static ?Capsule $capsule = null;
+
+    public static function boot(): Capsule
+    {
+        if (self::$capsule !== null) {
+            return self::$capsule;
+        }
+
+        $capsule = new Capsule();
+        $capsule->addConnection([
+            'driver' => 'mysql',
+            'host' => Config::env('DB_HOST', 'mysql'),
+            'port' => Config::envInt('DB_PORT', 3306),
+            'database' => Config::env('DB_DATABASE', 'melodyquest'),
+            'username' => Config::env('DB_USERNAME', 'root'),
+            'password' => Config::env('DB_PASSWORD', 'secret'),
+            'charset' => 'utf16',
+            'collation' => 'utf16_general_ci',
+            'prefix' => '',
+        ]);
+
+        $capsule->setAsGlobal();
+        $capsule->bootEloquent();
+
+        return self::$capsule = $capsule;
+    }
+}

--- a/apps/api-php/src/Exceptions/ApiException.php
+++ b/apps/api-php/src/Exceptions/ApiException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Exceptions;
+
+use RuntimeException;
+
+class ApiException extends RuntimeException
+{
+    public function __construct(
+        string $message,
+        private int $status = 400,
+        private string $errorCode = 'BAD_REQUEST',
+        private array $details = []
+    ) {
+        parent::__construct($message, $status);
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    public function getErrorCode(): string
+    {
+        return $this->errorCode;
+    }
+
+    public function getDetails(): array
+    {
+        return $this->details;
+    }
+}

--- a/apps/api-php/src/Helpers/YouTube.php
+++ b/apps/api-php/src/Helpers/YouTube.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Helpers;
+
+use InvalidArgumentException;
+
+class YouTube
+{
+    public static function extractVideoId(string $url): string
+    {
+        $url = trim($url);
+        if ($url === '') {
+            throw new InvalidArgumentException('YouTube URL is required');
+        }
+
+        if (preg_match('/^[A-Za-z0-9_-]{11}$/', $url) === 1) {
+            return $url;
+        }
+
+        $parsed = parse_url($url);
+        if ($parsed === false || !isset($parsed['host'])) {
+            throw new InvalidArgumentException('Invalid YouTube URL');
+        }
+
+        $host = strtolower($parsed['host']);
+        $path = $parsed['path'] ?? '';
+
+        if (str_contains($host, 'youtu.be')) {
+            $segments = array_values(array_filter(explode('/', $path)));
+            $candidate = $segments[0] ?? '';
+        } elseif (str_contains($host, 'youtube.com')) {
+            if (str_starts_with($path, '/watch')) {
+                parse_str($parsed['query'] ?? '', $query);
+                $candidate = $query['v'] ?? '';
+            } else {
+                $segments = array_values(array_filter(explode('/', $path)));
+                $candidate = $segments[1] ?? '';
+                if (($segments[0] ?? '') === 'embed' || ($segments[0] ?? '') === 'shorts') {
+                    $candidate = $segments[1] ?? '';
+                } elseif (($segments[0] ?? '') === 'v') {
+                    $candidate = $segments[1] ?? '';
+                }
+            }
+        } else {
+            throw new InvalidArgumentException('Unsupported YouTube host');
+        }
+
+        $candidate = trim($candidate ?? '');
+        if (preg_match('/^[A-Za-z0-9_-]{11}$/', $candidate) !== 1) {
+            throw new InvalidArgumentException('Unable to extract YouTube video id');
+        }
+
+        return $candidate;
+    }
+}

--- a/apps/api-php/src/Middleware/AdminAuthMiddleware.php
+++ b/apps/api-php/src/Middleware/AdminAuthMiddleware.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Middleware;
+
+use MelodyQuest\Api\Responses;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class AdminAuthMiddleware implements MiddlewareInterface
+{
+    public function __construct(private string $adminToken, private ResponseFactoryInterface $responseFactory)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $token = $request->getHeaderLine('X-Admin-Token');
+        if ($token === '' || !hash_equals($this->adminToken, $token)) {
+            return Responses::jsonErr($this->responseFactory, 'UNAUTHORIZED', 'Admin token invalid', 401);
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/apps/api-php/src/Middleware/CorsMiddleware.php
+++ b/apps/api-php/src/Middleware/CorsMiddleware.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Middleware;
+
+use MelodyQuest\Api\Responses;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class CorsMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param array<int, string> $allowedOrigins
+     */
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+        private array $allowedOrigins,
+        private bool $allowAll
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $origin = $request->getHeaderLine('Origin');
+        $isAllowed = $this->allowAll || $origin === '' || in_array($origin, $this->allowedOrigins, true);
+
+        if (strtoupper($request->getMethod()) === 'OPTIONS') {
+            if (!$isAllowed) {
+                return Responses::jsonErr($this->responseFactory, 'CORS_NOT_ALLOWED', 'Origin not allowed', 403);
+            }
+
+            $response = $this->responseFactory->createResponse(204);
+            return $this->applyHeaders($response, $origin);
+        }
+
+        if (!$isAllowed) {
+            return Responses::jsonErr($this->responseFactory, 'CORS_NOT_ALLOWED', 'Origin not allowed', 403);
+        }
+
+        $response = $handler->handle($request);
+
+        return $this->applyHeaders($response, $origin);
+    }
+
+    private function applyHeaders(ResponseInterface $response, string $origin): ResponseInterface
+    {
+        $allowOrigin = $this->allowAll ? ($origin !== '' ? $origin : '*') : $origin;
+
+        return $response
+            ->withHeader('Access-Control-Allow-Origin', $allowOrigin === '' ? '*' : $allowOrigin)
+            ->withHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Admin-Token')
+            ->withHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,PUT,DELETE,OPTIONS')
+            ->withHeader('Access-Control-Allow-Credentials', 'true');
+    }
+}

--- a/apps/api-php/src/Middleware/ErrorHandler.php
+++ b/apps/api-php/src/Middleware/ErrorHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Middleware;
+
+use MelodyQuest\Api\Exceptions\ApiException;
+use MelodyQuest\Api\Responses;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Exception\HttpException;
+use Throwable;
+
+class ErrorHandler
+{
+    public function __construct(private ResponseFactoryInterface $responseFactory)
+    {
+    }
+
+    public function __invoke(
+        ServerRequestInterface $request,
+        Throwable $exception,
+        bool $displayErrorDetails,
+        bool $logErrors,
+        bool $logErrorDetails
+    ): ResponseInterface {
+        $status = 500;
+        $code = 'SERVER_ERROR';
+        $message = 'An unexpected error occurred.';
+        $details = [];
+
+        if ($exception instanceof ApiException) {
+            $status = $exception->getStatus();
+            $code = $exception->getErrorCode();
+            $message = $exception->getMessage();
+            $details = $exception->getDetails();
+        } elseif ($exception instanceof HttpException) {
+            $status = $exception->getCode() > 0 ? $exception->getCode() : 500;
+            $message = $exception->getMessage();
+            $code = strtoupper(str_replace(' ', '_', $exception->getTitle() ?: 'HTTP_ERROR'));
+        } else {
+            $message = $exception->getMessage() !== '' ? $exception->getMessage() : $message;
+        }
+
+        if ($displayErrorDetails) {
+            $details['exception'] = [
+                'type' => $exception::class,
+                'message' => $exception->getMessage(),
+                'trace' => explode("\n", $exception->getTraceAsString()),
+            ];
+        }
+
+        return Responses::jsonErr($this->responseFactory, $code, $message, $status, $details);
+    }
+}

--- a/apps/api-php/src/Middleware/JsonBodyParser.php
+++ b/apps/api-php/src/Middleware/JsonBodyParser.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Middleware;
+
+use MelodyQuest\Api\Responses;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class JsonBodyParser implements MiddlewareInterface
+{
+    public function __construct(private ResponseFactoryInterface $responseFactory)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $method = strtoupper($request->getMethod());
+        if (in_array($method, ['GET', 'HEAD', 'OPTIONS'], true)) {
+            return $handler->handle($request);
+        }
+
+        $contentType = $request->getHeaderLine('Content-Type');
+        if ($contentType === '') {
+            return Responses::jsonErr($this->responseFactory, 'INVALID_CONTENT_TYPE', 'Content-Type header required', 415);
+        }
+
+        if (!str_contains(strtolower($contentType), 'application/json')) {
+            return Responses::jsonErr($this->responseFactory, 'INVALID_CONTENT_TYPE', 'Content-Type must be application/json', 415);
+        }
+
+        $body = (string) $request->getBody();
+        if ($body === '') {
+            $parsed = [];
+        } else {
+            try {
+                $parsed = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+            } catch (\JsonException $exception) {
+                return Responses::jsonErr($this->responseFactory, 'INVALID_JSON', 'Malformed JSON payload', 400, [
+                    'message' => $exception->getMessage(),
+                ]);
+            }
+        }
+
+        if (!is_array($parsed)) {
+            return Responses::jsonErr($this->responseFactory, 'INVALID_JSON', 'JSON body must decode to an object', 400);
+        }
+
+        return $handler->handle($request->withParsedBody($parsed));
+    }
+}

--- a/apps/api-php/src/Middleware/RateLimitMiddleware.php
+++ b/apps/api-php/src/Middleware/RateLimitMiddleware.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Middleware;
+
+use DateTimeImmutable;
+use MelodyQuest\Api\Responses;
+use Predis\ClientInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class RateLimitMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ClientInterface $redis,
+        private int $limitPerMinute,
+        private ResponseFactoryInterface $responseFactory
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (strtoupper($request->getMethod()) === 'OPTIONS') {
+            return $handler->handle($request);
+        }
+
+        $ip = $request->getServerParams()['REMOTE_ADDR'] ?? 'unknown';
+        $minute = (new DateTimeImmutable('now'))->format('YmdHi');
+        $key = sprintf('ratelimit:%s:%s', $ip, $minute);
+        $count = (int) $this->redis->incr($key);
+        if ($count === 1) {
+            $this->redis->expire($key, 60);
+        }
+
+        if ($count > $this->limitPerMinute) {
+            return Responses::jsonErr(
+                $this->responseFactory,
+                'RATE_LIMIT_EXCEEDED',
+                'Too many requests',
+                429,
+                ['limit_per_minute' => $this->limitPerMinute]
+            );
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/apps/api-php/src/Models/Category.php
+++ b/apps/api-php/src/Models/Category.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Category extends Model
+{
+    protected $table = 'categories';
+    public $timestamps = false;
+    protected $fillable = ['name', 'is_active'];
+
+    public function tracks(): HasMany
+    {
+        return $this->hasMany(Track::class);
+    }
+
+    public function games(): BelongsToMany
+    {
+        return $this->belongsToMany(Game::class, 'game_categories', 'category_id', 'game_id');
+    }
+}

--- a/apps/api-php/src/Models/Game.php
+++ b/apps/api-php/src/Models/Game.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Game extends Model
+{
+    protected $table = 'games';
+    public $timestamps = false;
+    protected $fillable = [
+        'host_user_id',
+        'status',
+        'round_count',
+        'created_at',
+        'started_at',
+        'ended_at',
+    ];
+
+    public function host(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'host_user_id');
+    }
+
+    public function rounds(): HasMany
+    {
+        return $this->hasMany(Round::class);
+    }
+
+    public function players(): HasMany
+    {
+        return $this->hasMany(GamePlayer::class);
+    }
+
+    public function categories(): BelongsToMany
+    {
+        return $this->belongsToMany(Category::class, 'game_categories', 'game_id', 'category_id');
+    }
+
+    public function scores(): HasMany
+    {
+        return $this->hasMany(Score::class);
+    }
+}

--- a/apps/api-php/src/Models/GameCategory.php
+++ b/apps/api-php/src/Models/GameCategory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GameCategory extends Model
+{
+    protected $table = 'game_categories';
+    public $timestamps = false;
+    protected $fillable = ['game_id', 'category_id'];
+
+    public function game(): BelongsTo
+    {
+        return $this->belongsTo(Game::class);
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+}

--- a/apps/api-php/src/Models/GamePlayer.php
+++ b/apps/api-php/src/Models/GamePlayer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GamePlayer extends Model
+{
+    protected $table = 'game_players';
+    public $timestamps = false;
+    protected $fillable = ['game_id', 'user_id'];
+
+    public function game(): BelongsTo
+    {
+        return $this->belongsTo(Game::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/apps/api-php/src/Models/Guess.php
+++ b/apps/api-php/src/Models/Guess.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Guess extends Model
+{
+    protected $table = 'guesses';
+    public $timestamps = false;
+    protected $fillable = ['round_id', 'user_id', 'guess_text', 'is_correct'];
+    protected $casts = [
+        'is_correct' => 'boolean',
+    ];
+
+    public function round(): BelongsTo
+    {
+        return $this->belongsTo(Round::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/apps/api-php/src/Models/Round.php
+++ b/apps/api-php/src/Models/Round.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Round extends Model
+{
+    protected $table = 'rounds';
+    public $timestamps = false;
+    protected $fillable = [
+        'game_id',
+        'round_number',
+        'track_id',
+        'started_at',
+        'ended_at',
+        'winner_user_id',
+        'reveal_video',
+    ];
+
+    protected $casts = [
+        'reveal_video' => 'boolean',
+    ];
+
+    public function game(): BelongsTo
+    {
+        return $this->belongsTo(Game::class);
+    }
+
+    public function track(): BelongsTo
+    {
+        return $this->belongsTo(Track::class);
+    }
+
+    public function winner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'winner_user_id');
+    }
+
+    public function guesses(): HasMany
+    {
+        return $this->hasMany(Guess::class);
+    }
+}

--- a/apps/api-php/src/Models/Score.php
+++ b/apps/api-php/src/Models/Score.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Score extends Model
+{
+    protected $table = 'scores';
+    public $timestamps = false;
+    protected $fillable = ['game_id', 'user_id', 'points'];
+
+    public function game(): BelongsTo
+    {
+        return $this->belongsTo(Game::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/apps/api-php/src/Models/Track.php
+++ b/apps/api-php/src/Models/Track.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Track extends Model
+{
+    protected $table = 'tracks';
+    public $timestamps = false;
+    protected $fillable = [
+        'youtube_url',
+        'youtube_video_id',
+        'category_id',
+        'title',
+        'cover_image_url',
+        'created_by',
+    ];
+
+    public function answers(): HasMany
+    {
+        return $this->hasMany(TrackAnswer::class);
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/apps/api-php/src/Models/TrackAnswer.php
+++ b/apps/api-php/src/Models/TrackAnswer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TrackAnswer extends Model
+{
+    protected $table = 'track_answers';
+    public $timestamps = false;
+    protected $fillable = ['track_id', 'answer_text'];
+
+    public function track(): BelongsTo
+    {
+        return $this->belongsTo(Track::class);
+    }
+}

--- a/apps/api-php/src/Models/User.php
+++ b/apps/api-php/src/Models/User.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class User extends Model
+{
+    protected $table = 'users';
+    public $timestamps = false;
+    protected $fillable = ['username'];
+
+    public function tracksCreated(): HasMany
+    {
+        return $this->hasMany(Track::class, 'created_by');
+    }
+
+    public function hostedGames(): HasMany
+    {
+        return $this->hasMany(Game::class, 'host_user_id');
+    }
+}

--- a/apps/api-php/src/RedisBus.php
+++ b/apps/api-php/src/RedisBus.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api;
+
+use Predis\Client;
+
+class RedisBus
+{
+    private Client $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public static function create(): self
+    {
+        $client = new Client([
+            'scheme' => 'tcp',
+            'host' => Config::env('REDIS_HOST', 'redis'),
+            'port' => Config::envInt('REDIS_PORT', 6379),
+        ], [
+            'parameters' => [
+                'password' => Config::env('REDIS_PASSWORD'),
+            ],
+        ]);
+
+        return new self($client);
+    }
+
+    public function client(): Client
+    {
+        return $this->client;
+    }
+
+    public function publish(string $channel, array $payload): void
+    {
+        $this->client->publish($channel, json_encode($payload, JSON_THROW_ON_ERROR));
+    }
+
+    public static function channelGame(int $gameId): string
+    {
+        return sprintf('game:%d', $gameId);
+    }
+}

--- a/apps/api-php/src/Responses.php
+++ b/apps/api-php/src/Responses.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class Responses
+{
+    public static function jsonOk(ResponseFactoryInterface $factory, mixed $data, int $status = 200): ResponseInterface
+    {
+        $response = $factory->createResponse($status);
+        $payload = [
+            'ok' => true,
+            'data' => $data,
+        ];
+
+        $response->getBody()->write(json_encode($payload, JSON_THROW_ON_ERROR));
+
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    public static function jsonErr(
+        ResponseFactoryInterface $factory,
+        string $code,
+        string $message,
+        int $status = 400,
+        array $details = []
+    ): ResponseInterface {
+        $response = $factory->createResponse($status);
+        $payload = [
+            'ok' => false,
+            'error' => [
+                'code' => $code,
+                'message' => $message,
+            ],
+        ];
+
+        if ($details !== []) {
+            $payload['error']['details'] = $details;
+        }
+
+        $response->getBody()->write(json_encode($payload, JSON_THROW_ON_ERROR));
+
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+}

--- a/apps/api-php/src/Routes/AdminRoutes.php
+++ b/apps/api-php/src/Routes/AdminRoutes.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Routes;
+
+use Illuminate\Database\QueryException;
+use MelodyQuest\Api\Middleware\AdminAuthMiddleware;
+use MelodyQuest\Api\Models\Category;
+use MelodyQuest\Api\Models\Track;
+use MelodyQuest\Api\Responses;
+use MelodyQuest\Api\Services\TrackService;
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Validator as v;
+use Slim\App;
+use Slim\Routing\RouteCollectorProxy;
+
+class AdminRoutes
+{
+    public static function register(App $app, TrackService $trackService, AdminAuthMiddleware $adminAuth): void
+    {
+        $responseFactory = $app->getResponseFactory();
+
+        $app->group('/api/admin', function (RouteCollectorProxy $group) use ($trackService, $responseFactory) {
+            $group->post('/categories', function ($request) use ($responseFactory) {
+                $body = (array) $request->getParsedBody();
+
+                $validator = v::key('name', v::stringType()->length(1, 128));
+
+                try {
+                    $validator->assert($body);
+                } catch (NestedValidationException $exception) {
+                    return Responses::jsonErr(
+                        $responseFactory,
+                        'VALIDATION_ERROR',
+                        'Invalid category data',
+                        422,
+                        $exception->getMessages()
+                    );
+                }
+
+                try {
+                    $category = Category::create([
+                        'name' => trim($body['name']),
+                        'is_active' => 1,
+                    ]);
+                } catch (QueryException $exception) {
+                    if (str_contains(strtolower($exception->getMessage()), 'duplicate')) {
+                        return Responses::jsonErr($responseFactory, 'CATEGORY_EXISTS', 'Category already exists', 409);
+                    }
+
+                    throw $exception;
+                }
+
+                return Responses::jsonOk($responseFactory, $category->toArray(), 201);
+            });
+
+            $group->get('/categories', function () use ($responseFactory) {
+                $categories = Category::orderBy('name')->get();
+                return Responses::jsonOk($responseFactory, $categories->toArray());
+            });
+
+            $group->patch('/categories/{id}', function ($request, $response, array $args) use ($responseFactory) {
+                $body = (array) $request->getParsedBody();
+                $category = Category::find($args['id']);
+
+                if (!$category) {
+                    return Responses::jsonErr($responseFactory, 'NOT_FOUND', 'Category not found', 404);
+                }
+
+                $validator = v::arrayType()->notEmpty();
+                try {
+                    $validator->assert($body);
+                } catch (NestedValidationException $exception) {
+                    return Responses::jsonErr(
+                        $responseFactory,
+                        'VALIDATION_ERROR',
+                        'Invalid category data',
+                        422,
+                        $exception->getMessages()
+                    );
+                }
+
+                if (array_key_exists('name', $body)) {
+                    $category->name = trim((string) $body['name']);
+                }
+                if (array_key_exists('is_active', $body)) {
+                    $category->is_active = (int) $body['is_active'] ? 1 : 0;
+                }
+                try {
+                    $category->save();
+                } catch (QueryException $exception) {
+                    if (str_contains(strtolower($exception->getMessage()), 'duplicate')) {
+                        return Responses::jsonErr($responseFactory, 'CATEGORY_EXISTS', 'Category already exists', 409);
+                    }
+
+                    throw $exception;
+                }
+
+                return Responses::jsonOk($responseFactory, $category->toArray());
+            });
+
+            $group->post('/tracks', function ($request) use ($trackService, $responseFactory) {
+                $body = (array) $request->getParsedBody();
+
+                $validator = v::key('youtube_url', v::stringType()->length(1, 255))
+                    ->key('category_id', v::intType()->positive())
+                    ->key('answers', v::arrayType(), false)
+                    ->key('title', v::optional(v::stringType()->length(0, 255)))
+                    ->key('cover_image_url', v::optional(v::stringType()->length(0, 255)));
+
+                try {
+                    $validator->assert($body);
+                } catch (NestedValidationException $exception) {
+                    return Responses::jsonErr(
+                        $responseFactory,
+                        'VALIDATION_ERROR',
+                        'Invalid track data',
+                        422,
+                        $exception->getMessages()
+                    );
+                }
+
+                try {
+                    $track = $trackService->addTrack($body);
+                } catch (\Throwable $exception) {
+                    return Responses::jsonErr(
+                        $responseFactory,
+                        'TRACK_CREATION_FAILED',
+                        $exception->getMessage(),
+                        400
+                    );
+                }
+
+                return Responses::jsonOk($responseFactory, $track->toArray(), 201);
+            });
+
+            $group->get('/tracks', function ($request) use ($trackService, $responseFactory) {
+                $categoryId = $request->getQueryParams()['category_id'] ?? null;
+                $q = $request->getQueryParams()['q'] ?? null;
+
+                $categoryId = $categoryId !== null ? (int) $categoryId : null;
+                $q = $q !== null ? trim((string) $q) : null;
+
+                $tracks = $trackService->searchTracks($categoryId, $q);
+
+                return Responses::jsonOk($responseFactory, $tracks->toArray());
+            });
+
+            $group->post('/tracks/{id}/answers', function ($request, $response, array $args) use ($trackService, $responseFactory) {
+                $body = (array) $request->getParsedBody();
+                $validator = v::key('answers', v::arrayType()->notEmpty());
+
+                try {
+                    $validator->assert($body);
+                } catch (NestedValidationException $exception) {
+                    return Responses::jsonErr(
+                        $responseFactory,
+                        'VALIDATION_ERROR',
+                        'Invalid answers payload',
+                        422,
+                        $exception->getMessages()
+                    );
+                }
+
+                $track = Track::find($args['id']);
+                if (!$track) {
+                    return Responses::jsonErr($responseFactory, 'NOT_FOUND', 'Track not found', 404);
+                }
+
+                try {
+                    $track = $trackService->addAnswers($track, $body['answers']);
+                } catch (\Throwable $exception) {
+                    return Responses::jsonErr(
+                        $responseFactory,
+                        'TRACK_UPDATE_FAILED',
+                        $exception->getMessage(),
+                        400
+                    );
+                }
+
+                return Responses::jsonOk($responseFactory, $track->toArray());
+            });
+        })->add($adminAuth);
+    }
+}

--- a/apps/api-php/src/Routes/HealthRoutes.php
+++ b/apps/api-php/src/Routes/HealthRoutes.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Routes;
+
+use MelodyQuest\Api\Responses;
+use Slim\App;
+
+class HealthRoutes
+{
+    public static function register(App $app): void
+    {
+        $responseFactory = $app->getResponseFactory();
+
+        $app->get('/api/health', function () use ($responseFactory) {
+            return Responses::jsonOk($responseFactory, ['status' => 'ok']);
+        });
+    }
+}

--- a/apps/api-php/src/Routes/PlayerRoutes.php
+++ b/apps/api-php/src/Routes/PlayerRoutes.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Routes;
+
+use MelodyQuest\Api\Exceptions\ApiException;
+use MelodyQuest\Api\Models\User;
+use MelodyQuest\Api\Responses;
+use MelodyQuest\Api\Services\GameService;
+use MelodyQuest\Api\Services\GuessService;
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Validator as v;
+use Slim\App;
+
+class PlayerRoutes
+{
+    public static function register(App $app, GameService $gameService, GuessService $guessService): void
+    {
+        $responseFactory = $app->getResponseFactory();
+
+        $app->post('/api/users', function ($request) use ($responseFactory) {
+            $body = (array) $request->getParsedBody();
+            $validator = v::key('username', v::stringType()->length(1, 64));
+
+            try {
+                $validator->assert($body);
+            } catch (NestedValidationException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    'VALIDATION_ERROR',
+                    'Invalid user data',
+                    422,
+                    $exception->getMessages()
+                );
+            }
+
+            $username = trim($body['username']);
+            $user = User::firstOrCreate(['username' => $username]);
+
+            $status = $user->wasRecentlyCreated ? 201 : 200;
+
+            return Responses::jsonOk($responseFactory, $user->toArray(), $status);
+        });
+
+        $app->post('/api/games', function ($request) use ($gameService, $responseFactory) {
+            $body = (array) $request->getParsedBody();
+            $validator = v::key('host_user_id', v::intType()->positive())
+                ->key('round_count', v::intType()->positive())
+                ->key('category_ids', v::arrayType()->notEmpty());
+
+            try {
+                $validator->assert($body);
+            } catch (NestedValidationException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    'VALIDATION_ERROR',
+                    'Invalid game data',
+                    422,
+                    $exception->getMessages()
+                );
+            }
+
+            try {
+                $game = $gameService->createGame((int) $body['host_user_id'], (int) $body['round_count'], $body['category_ids']);
+            } catch (ApiException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    $exception->getErrorCode(),
+                    $exception->getMessage(),
+                    $exception->getStatus(),
+                    $exception->getDetails()
+                );
+            }
+
+            return Responses::jsonOk($responseFactory, $game->toArray(), 201);
+        });
+
+        $app->post('/api/games/{id}/join', function ($request, $response, array $args) use ($gameService, $responseFactory) {
+            $body = (array) $request->getParsedBody();
+            $validator = v::key('user_id', v::intType()->positive());
+
+            try {
+                $validator->assert($body);
+            } catch (NestedValidationException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    'VALIDATION_ERROR',
+                    'Invalid join payload',
+                    422,
+                    $exception->getMessages()
+                );
+            }
+
+            try {
+                $result = $gameService->addPlayer((int) $args['id'], (int) $body['user_id']);
+            } catch (ApiException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    $exception->getErrorCode(),
+                    $exception->getMessage(),
+                    $exception->getStatus(),
+                    $exception->getDetails()
+                );
+            }
+
+            $status = $result['created'] ? 201 : 200;
+
+            return Responses::jsonOk($responseFactory, $result['player']->toArray(), $status);
+        });
+
+        $app->post('/api/games/{id}/start', function ($request, $response, array $args) use ($gameService, $responseFactory) {
+            $body = (array) $request->getParsedBody();
+            $validator = v::key('user_id', v::intType()->positive());
+
+            try {
+                $validator->assert($body);
+            } catch (NestedValidationException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    'VALIDATION_ERROR',
+                    'Invalid start payload',
+                    422,
+                    $exception->getMessages()
+                );
+            }
+
+            try {
+                $round = $gameService->startGame((int) $args['id'], (int) $body['user_id']);
+            } catch (ApiException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    $exception->getErrorCode(),
+                    $exception->getMessage(),
+                    $exception->getStatus(),
+                    $exception->getDetails()
+                );
+            }
+
+            return Responses::jsonOk($responseFactory, $round->toArray());
+        });
+
+        $app->get('/api/games/{id}/state', function ($request, $response, array $args) use ($gameService, $responseFactory) {
+            try {
+                $state = $gameService->getState((int) $args['id']);
+            } catch (ApiException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    $exception->getErrorCode(),
+                    $exception->getMessage(),
+                    $exception->getStatus(),
+                    $exception->getDetails()
+                );
+            }
+
+            return Responses::jsonOk($responseFactory, $state);
+        });
+
+        $app->post('/api/games/{id}/next', function ($request, $response, array $args) use ($gameService, $responseFactory) {
+            $body = (array) $request->getParsedBody();
+            $validator = v::key('user_id', v::intType()->positive());
+
+            try {
+                $validator->assert($body);
+            } catch (NestedValidationException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    'VALIDATION_ERROR',
+                    'Invalid next payload',
+                    422,
+                    $exception->getMessages()
+                );
+            }
+
+            try {
+                $round = $gameService->nextRound((int) $args['id'], (int) $body['user_id']);
+            } catch (ApiException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    $exception->getErrorCode(),
+                    $exception->getMessage(),
+                    $exception->getStatus(),
+                    $exception->getDetails()
+                );
+            }
+
+            return Responses::jsonOk($responseFactory, $round->toArray());
+        });
+
+        $app->post('/api/rounds/{id}/guess', function ($request, $response, array $args) use ($guessService, $responseFactory) {
+            $body = (array) $request->getParsedBody();
+            $validator = v::key('user_id', v::intType()->positive())
+                ->key('guess_text', v::stringType()->length(1, 255));
+
+            try {
+                $validator->assert($body);
+            } catch (NestedValidationException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    'VALIDATION_ERROR',
+                    'Invalid guess payload',
+                    422,
+                    $exception->getMessages()
+                );
+            }
+
+            try {
+                $result = $guessService->submitGuess((int) $args['id'], (int) $body['user_id'], (string) $body['guess_text']);
+            } catch (ApiException $exception) {
+                return Responses::jsonErr(
+                    $responseFactory,
+                    $exception->getErrorCode(),
+                    $exception->getMessage(),
+                    $exception->getStatus(),
+                    $exception->getDetails()
+                );
+            }
+
+            return Responses::jsonOk($responseFactory, $result);
+        });
+    }
+}

--- a/apps/api-php/src/Services/GameService.php
+++ b/apps/api-php/src/Services/GameService.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Services;
+
+use DateTimeImmutable;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use MelodyQuest\Api\Exceptions\ApiException;
+use MelodyQuest\Api\RedisBus;
+use MelodyQuest\Api\Models\Game;
+use MelodyQuest\Api\Models\GameCategory;
+use MelodyQuest\Api\Models\GamePlayer;
+use MelodyQuest\Api\Models\Round;
+use MelodyQuest\Api\Models\Track;
+use MelodyQuest\Api\Models\User;
+
+class GameService
+{
+    public function __construct(private RedisBus $bus)
+    {
+    }
+
+    public function createGame(int $hostUserId, int $roundCount, array $categoryIds): Game
+    {
+        return Capsule::connection()->transaction(function () use ($hostUserId, $roundCount, $categoryIds) {
+            $host = User::find($hostUserId);
+            if (!$host) {
+                throw new ApiException('Host user not found', 404, 'HOST_NOT_FOUND');
+            }
+
+            $game = Game::create([
+                'host_user_id' => $hostUserId,
+                'round_count' => $roundCount,
+                'status' => 'LOBBY',
+            ]);
+
+            $uniqueCategories = array_values(array_unique(array_map('intval', $categoryIds)));
+            foreach ($uniqueCategories as $categoryId) {
+                GameCategory::create([
+                    'game_id' => $game->id,
+                    'category_id' => $categoryId,
+                ]);
+            }
+
+            GamePlayer::firstOrCreate([
+                'game_id' => $game->id,
+                'user_id' => $hostUserId,
+            ]);
+
+            return $game->load(['categories', 'players.user']);
+        });
+    }
+
+    /**
+     * @return array{player: GamePlayer, created: bool}
+     */
+    public function addPlayer(int $gameId, int $userId): array
+    {
+        return Capsule::connection()->transaction(function () use ($gameId, $userId) {
+            $game = Game::find($gameId);
+            if (!$game) {
+                throw new ApiException('Game not found', 404, 'GAME_NOT_FOUND');
+            }
+
+            $user = User::find($userId);
+            if (!$user) {
+                throw new ApiException('User not found', 404, 'USER_NOT_FOUND');
+            }
+
+            $player = GamePlayer::firstOrCreate([
+                'game_id' => $game->id,
+                'user_id' => $user->id,
+            ]);
+
+            $created = $player->wasRecentlyCreated;
+
+            if ($created) {
+                $this->bus->publish(
+                    RedisBus::channelGame($game->id),
+                    [
+                        'type' => 'PLAYER_JOINED',
+                        'user_id' => $player->user_id,
+                    ]
+                );
+            }
+
+            return [
+                'player' => $player->load('user'),
+                'created' => $created,
+            ];
+        });
+    }
+
+    public function startGame(int $gameId, int $initiatorId): Round
+    {
+        return Capsule::connection()->transaction(function () use ($gameId, $initiatorId) {
+            /** @var Game|null $game */
+            $game = Game::with(['categories'])->lockForUpdate()->find($gameId);
+            if (!$game) {
+                throw new ApiException('Game not found', 404, 'GAME_NOT_FOUND');
+            }
+
+            if ($game->host_user_id !== $initiatorId) {
+                throw new ApiException('Only the host can start the game', 403, 'FORBIDDEN');
+            }
+
+            if ($game->status !== 'LOBBY') {
+                throw new ApiException('Game already started', 409, 'GAME_ALREADY_STARTED');
+            }
+
+            $categoryIds = $game->categories->pluck('id')->all();
+            if ($categoryIds === []) {
+                throw new ApiException('No categories configured for this game', 400, 'NO_CATEGORIES');
+            }
+
+            $tracks = Track::query()
+                ->whereIn('category_id', $categoryIds)
+                ->inRandomOrder()
+                ->limit($game->round_count)
+                ->get();
+
+            if ($tracks->count() < $game->round_count) {
+                throw new ApiException('Not enough tracks to start the game', 400, 'NOT_ENOUGH_TRACKS');
+            }
+
+            Round::where('game_id', $game->id)->delete();
+
+            $rounds = [];
+            $roundNumber = 1;
+            foreach ($tracks as $track) {
+                $rounds[] = Round::create([
+                    'game_id' => $game->id,
+                    'round_number' => $roundNumber++,
+                    'track_id' => $track->id,
+                ]);
+            }
+
+            $firstRound = $rounds[0];
+            $firstRound->started_at = (new DateTimeImmutable())->format('Y-m-d H:i:s');
+            $firstRound->save();
+
+            $game->status = 'RUNNING';
+            $game->started_at = (new DateTimeImmutable())->format('Y-m-d H:i:s');
+            $game->save();
+
+            $this->bus->publish(
+                RedisBus::channelGame($game->id),
+                [
+                    'type' => 'ROUND_START',
+                    'round_id' => $firstRound->id,
+                    'track_id' => $firstRound->track_id,
+                ]
+            );
+
+            return $firstRound->load('track');
+        });
+    }
+
+    public function nextRound(int $gameId, int $userId): Round
+    {
+        return Capsule::connection()->transaction(function () use ($gameId, $userId) {
+            /** @var Game|null $game */
+            $game = Game::with(['rounds' => function ($query) {
+                $query->orderBy('round_number');
+            }])->lockForUpdate()->find($gameId);
+
+            if (!$game) {
+                throw new ApiException('Game not found', 404, 'GAME_NOT_FOUND');
+            }
+
+            if ($game->host_user_id !== $userId) {
+                throw new ApiException('Only the host can advance the game', 403, 'FORBIDDEN');
+            }
+
+            $nextRound = $game->rounds->first(function (Round $round) {
+                return $round->started_at === null;
+            });
+
+            if (!$nextRound) {
+                throw new ApiException('No more rounds to start', 400, 'NO_ROUNDS');
+            }
+
+            $nextRound->started_at = (new DateTimeImmutable())->format('Y-m-d H:i:s');
+            $nextRound->reveal_video = false;
+            $nextRound->winner_user_id = null;
+            $nextRound->ended_at = null;
+            $nextRound->save();
+
+            $this->bus->publish(
+                RedisBus::channelGame($game->id),
+                [
+                    'type' => 'ROUND_START',
+                    'round_id' => $nextRound->id,
+                    'track_id' => $nextRound->track_id,
+                ]
+            );
+
+            return $nextRound->load('track');
+        });
+    }
+
+    public function getState(int $gameId): array
+    {
+        $game = Game::with([
+            'players.user',
+            'rounds' => function ($query) {
+                $query->orderBy('round_number');
+            },
+            'scores' => function ($query) {
+                $query->orderByDesc('points');
+            },
+            'categories',
+        ])->find($gameId);
+
+        if (!$game) {
+            throw new ApiException('Game not found', 404, 'GAME_NOT_FOUND');
+        }
+
+        $currentRound = $game->rounds->first(function (Round $round) {
+            return $round->started_at !== null && $round->ended_at === null;
+        });
+
+        if (!$currentRound) {
+            $currentRound = $game->rounds->first(function (Round $round) {
+                return $round->started_at === null;
+            });
+        }
+
+        $scores = $game->scores->load('user');
+
+        return [
+            'game' => $game->toArray(),
+            'players' => $game->players->map(fn ($player) => $player->toArray())->all(),
+            'currentRound' => $currentRound?->load('track')->toArray(),
+            'scores' => $scores->map(fn ($score) => $score->toArray())->all(),
+            'rules' => [
+                'round_count' => $game->round_count,
+            ],
+        ];
+    }
+}

--- a/apps/api-php/src/Services/GuessService.php
+++ b/apps/api-php/src/Services/GuessService.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Services;
+
+use DateTimeImmutable;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use MelodyQuest\Api\Exceptions\ApiException;
+use MelodyQuest\Api\Models\GamePlayer;
+use MelodyQuest\Api\Models\Guess;
+use MelodyQuest\Api\Models\Round;
+use MelodyQuest\Api\Models\Score;
+use MelodyQuest\Api\Models\TrackAnswer;
+use MelodyQuest\Api\RedisBus;
+
+class GuessService
+{
+    public function __construct(private RedisBus $bus)
+    {
+    }
+
+    public function submitGuess(int $roundId, int $userId, string $guessText): array
+    {
+        $round = Round::with(['game', 'track'])->find($roundId);
+        if (!$round) {
+            throw new ApiException('Round not found', 404, 'ROUND_NOT_FOUND');
+        }
+
+        $game = $round->game;
+        if (!$game) {
+            throw new ApiException('Game not found for round', 404, 'GAME_NOT_FOUND');
+        }
+
+        $playerExists = GamePlayer::where('game_id', $game->id)
+            ->where('user_id', $userId)
+            ->exists();
+
+        if (!$playerExists) {
+            throw new ApiException('Player is not part of this game', 403, 'FORBIDDEN');
+        }
+
+        if ($game->status !== 'RUNNING') {
+            throw new ApiException('Game is not running', 409, 'GAME_NOT_RUNNING');
+        }
+
+        if ($round->started_at === null) {
+            throw new ApiException('Round has not started yet', 409, 'ROUND_NOT_STARTED');
+        }
+
+        if ($round->ended_at !== null) {
+            throw new ApiException('Round already ended', 409, 'ROUND_ENDED');
+        }
+
+        $guessText = trim($guessText);
+        if ($guessText === '') {
+            throw new ApiException('Guess text is required', 422, 'VALIDATION_ERROR');
+        }
+
+        $now = (new DateTimeImmutable())->format('Y-m-d H:i:s');
+        $result = Capsule::connection()->transaction(function () use ($round, $userId, $guessText, $now) {
+            $normalizedRow = Capsule::selectOne('SELECT fn_normalize(?) AS norm', [$guessText]);
+            $normalized = $normalizedRow->norm ?? '';
+
+            $isCorrect = TrackAnswer::where('track_id', $round->track_id)
+                ->whereRaw('normalized = ?', [$normalized])
+                ->exists();
+
+            Guess::create([
+                'round_id' => $round->id,
+                'user_id' => $userId,
+                'guess_text' => $guessText,
+                'is_correct' => $isCorrect,
+            ]);
+
+            $event = null;
+            if ($isCorrect && $round->winner_user_id === null) {
+                $round->winner_user_id = $userId;
+                $round->ended_at = $now;
+                $round->reveal_video = true;
+                $round->save();
+
+                $score = Score::firstOrCreate([
+                    'game_id' => $round->game_id,
+                    'user_id' => $userId,
+                ], [
+                    'points' => 0,
+                ]);
+                $score->increment('points');
+
+                $event = [
+                    'type' => 'ROUND_SOLVED',
+                    'round_id' => $round->id,
+                    'winner_user_id' => $userId,
+                    'track' => [
+                        'id' => $round->track->id,
+                        'title' => $round->track->title,
+                        'youtube_video_id' => $round->track->youtube_video_id,
+                        'cover_image_url' => $round->track->cover_image_url,
+                    ],
+                ];
+            }
+
+            return [
+                'is_correct' => $isCorrect,
+                'event' => $event,
+            ];
+        });
+
+        if ($result['event'] !== null) {
+            $this->bus->publish(RedisBus::channelGame($round->game_id), $result['event']);
+        }
+
+        return [
+            'is_correct' => $result['is_correct'],
+        ];
+    }
+}

--- a/apps/api-php/src/Services/TrackService.php
+++ b/apps/api-php/src/Services/TrackService.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelodyQuest\Api\Services;
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\QueryException;
+use InvalidArgumentException;
+use MelodyQuest\Api\Helpers\YouTube;
+use MelodyQuest\Api\Models\Track;
+use MelodyQuest\Api\Models\TrackAnswer;
+
+class TrackService
+{
+    public function addTrack(array $payload): Track
+    {
+        if (!isset($payload['youtube_url'], $payload['category_id'])) {
+            throw new InvalidArgumentException('Missing required track fields');
+        }
+
+        $videoId = YouTube::extractVideoId((string) $payload['youtube_url']);
+        $answers = array_map('strval', $payload['answers'] ?? []);
+
+        return Capsule::connection()->transaction(function () use ($payload, $videoId, $answers) {
+            $track = Track::create([
+                'youtube_url' => $payload['youtube_url'],
+                'youtube_video_id' => $videoId,
+                'category_id' => (int) $payload['category_id'],
+                'title' => $payload['title'] ?? null,
+                'cover_image_url' => $payload['cover_image_url'] ?? null,
+                'created_by' => $payload['created_by'] ?? null,
+            ]);
+
+            $uniqueAnswers = [];
+            foreach ($answers as $answer) {
+                $trimmed = trim($answer);
+                if ($trimmed === '') {
+                    continue;
+                }
+                $key = mb_strtolower($trimmed);
+                $uniqueAnswers[$key] = $trimmed;
+            }
+
+            foreach ($uniqueAnswers as $answer) {
+                try {
+                    TrackAnswer::create([
+                        'track_id' => $track->id,
+                        'answer_text' => $answer,
+                    ]);
+                } catch (QueryException $exception) {
+                    if (str_contains(strtolower($exception->getMessage()), 'uq_track_answers')) {
+                        continue;
+                    }
+
+                    throw $exception;
+                }
+            }
+
+            return $track->load('answers');
+        });
+    }
+
+    public function addAnswers(Track $track, array $answers): Track
+    {
+        return Capsule::connection()->transaction(function () use ($track, $answers) {
+            $uniqueAnswers = [];
+            foreach ($answers as $answer) {
+                $trimmed = trim((string) $answer);
+                if ($trimmed === '') {
+                    continue;
+                }
+                $key = mb_strtolower($trimmed);
+                $uniqueAnswers[$key] = $trimmed;
+            }
+
+            foreach ($uniqueAnswers as $answer) {
+                try {
+                    TrackAnswer::create([
+                        'track_id' => $track->id,
+                        'answer_text' => $answer,
+                    ]);
+                } catch (QueryException $exception) {
+                    if (str_contains(strtolower($exception->getMessage()), 'uq_track_answers')) {
+                        continue;
+                    }
+
+                    throw $exception;
+                }
+            }
+
+            return $track->load('answers');
+        });
+    }
+
+    public function searchTracks(?int $categoryId, ?string $query): Collection
+    {
+        $builder = Track::query()->with(['answers', 'category']);
+
+        if ($categoryId !== null) {
+            $builder->where('category_id', $categoryId);
+        }
+
+        if ($query !== null && $query !== '') {
+            $pattern = '%' . $query . '%';
+            $builder->where(function ($q) use ($pattern) {
+                $q->where('title', 'like', $pattern)
+                    ->orWhere('youtube_url', 'like', $pattern);
+            });
+        }
+
+        return $builder->orderByDesc('id')->limit(50)->get();
+    }
+}

--- a/apps/realtime-node/.gitignore
+++ b/apps/realtime-node/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/apps/realtime-node/Dockerfile
+++ b/apps/realtime-node/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --production --ignore-scripts && npm cache clean --force
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --ignore-scripts
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY package.json ./
+USER node
+EXPOSE 3000
+CMD ["node", "dist/index.js"]

--- a/apps/realtime-node/README.md
+++ b/apps/realtime-node/README.md
@@ -1,0 +1,81 @@
+# MelodyQuest Realtime Gateway
+
+Socket.IO gateway that relays MelodyQuest game updates over WebSockets and Redis.
+
+## Prerequisites
+
+- Node.js 20+
+- Redis instance reachable at the configured host/port (defaults: `redis:6379`)
+
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `APP_ENV` | `development` | Enables permissive CORS when set to `development`. |
+| `ALLOWED_ORIGINS` | `*` | Comma separated list of allowed origins when not in development. |
+| `REDIS_HOST` | `redis` | Redis hostname. |
+| `REDIS_PORT` | `6379` | Redis port. |
+| `REALTIME_PORT` | `3000` | HTTP port to expose Express and Socket.IO. |
+| `REALTIME_HMAC_SECRET` | _(required for token verification)_ | Secret used to verify handshake tokens. |
+| `ADMIN_TOKEN` | _(optional)_ | Enables `/internal/broadcast` endpoint when set. |
+
+## Installation
+
+```bash
+npm install
+```
+
+## Development
+
+```bash
+npm run dev
+```
+
+## Build & Run
+
+```bash
+npm run build
+npm start
+```
+
+The server listens on `REALTIME_PORT` (default `3000`).
+
+## Docker
+
+The provided `Dockerfile` builds the TypeScript sources into a minimal runtime image.
+
+```bash
+docker build -t melodyquest-realtime .
+docker run --rm -p 3000:3000 \
+  -e APP_ENV=development \
+  -e REALTIME_HMAC_SECRET=change-me \
+  -e REDIS_HOST=redis \
+  -e REDIS_PORT=6379 \
+  melodyquest-realtime
+```
+
+## Health check
+
+```bash
+curl http://localhost:3000/healthz
+```
+
+## Manual broadcast (debug)
+
+When `ADMIN_TOKEN` is set, the gateway exposes `POST /internal/broadcast` to relay a payload to connected clients.
+
+```bash
+curl -X POST http://localhost:3000/internal/broadcast \
+  -H "Content-Type: application/json" \
+  -H "X-Internal-Token: $ADMIN_TOKEN" \
+  -d '{"channel":"game:1","payload":{"type":"ROUND_START","roundId":10,"track_id":5}}'
+```
+
+## Redis relay test
+
+1. Connect a client to `ws://localhost:3000/socket.io/?gameId=1&userId=42&username=Tester`.
+2. Publish a Redis message:
+   ```bash
+   redis-cli -h redis -p 6379 PUBLISH "game:1" '{"type":"ROUND_START","roundId":10,"track_id":5}'
+   ```
+3. The client in room `game:1` should receive the `round:start` event with the JSON payload above.

--- a/apps/realtime-node/package-lock.json
+++ b/apps/realtime-node/package-lock.json
@@ -1,0 +1,2065 @@
+{
+  "name": "melodyquest-realtime",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "melodyquest-realtime",
+      "version": "1.0.0",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "express": "^4.18.2",
+        "ioredis": "^5.3.2",
+        "socket.io": "^4.7.5",
+        "zod": "^3.22.4"
+      },
+      "devDependencies": {
+        "@types/cors": "^2.8.18",
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.11.17",
+        "ts-node-dev": "^2.0.0",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.4.0.tgz",
+      "integrity": "sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
+      "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-zBF6vZJn1IaMpg3xUF25VK3gd3l8zwE0ZLRX7dsQyQi+jp4E8mMDJNGDYnYse+bQhYwWERTxVwHpi3dMOq7RKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.9.tgz",
+      "integrity": "sha512-dOTIuqpWLyl3BBXU3maNQsS4A3zuuoYRNIvYSxxhebPfXg2mzWQEPne/nlJ37yOse6uGgR386uTpdsx4D0QZWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/dynamic-dedupe": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
+      "integrity": "sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ioredis": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.1.tgz",
+      "integrity": "sha512-Qho8TgIamqEPdgiMadJwzRMW3TudIg6vpg4YONokGDudy4eqRIJtDbVX72pfLBcWxvbn3qm/40TyGUObdW4tLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.4.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node-dev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.1",
+        "dynamic-dedupe": "^0.3.0",
+        "minimist": "^1.2.6",
+        "mkdirp": "^1.0.4",
+        "resolve": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "source-map-support": "^0.5.12",
+        "tree-kill": "^1.2.2",
+        "ts-node": "^10.4.0",
+        "tsconfig": "^7.0.0"
+      },
+      "bin": {
+        "ts-node-dev": "lib/bin.js",
+        "tsnd": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "*",
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/strip-bom": "^3.0.0",
+        "@types/strip-json-comments": "0.0.30",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "^2.0.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/apps/realtime-node/package.json
+++ b/apps/realtime-node/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "melodyquest-realtime",
+  "version": "1.0.0",
+  "description": "Realtime gateway for MelodyQuest Socket.IO events",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpileOnly src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "ioredis": "^5.3.2",
+    "socket.io": "^4.7.5",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.18",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.17",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/apps/realtime-node/src/index.ts
+++ b/apps/realtime-node/src/index.ts
@@ -1,0 +1,339 @@
+import http from 'http';
+import crypto from 'crypto';
+import express from 'express';
+import cors from 'cors';
+import { Server, Socket } from 'socket.io';
+import Redis from 'ioredis';
+import { BroadcastPayloadSchema, HelloPayload, HelloPayloadSchema, RedisEvent, RedisEventSchema } from './types';
+
+const appEnv = process.env.APP_ENV ?? 'development';
+const isDev = appEnv === 'development';
+const realtimePort = Number(process.env.REALTIME_PORT ?? 3000);
+const redisHost = process.env.REDIS_HOST ?? 'redis';
+const redisPort = Number(process.env.REDIS_PORT ?? 6379);
+const allowedOriginsConfig = process.env.ALLOWED_ORIGINS ?? '*';
+const allowedOrigins = allowedOriginsConfig
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter((origin) => origin.length > 0);
+const allowedOriginSet = new Set(allowedOrigins);
+const allowAnyOrigin = isDev || allowedOriginSet.has('*');
+const hmacSecret = process.env.REALTIME_HMAC_SECRET ?? '';
+const internalToken = process.env.ADMIN_TOKEN;
+
+const app = express();
+
+const corsOptions: cors.CorsOptions = {
+  origin(origin, callback) {
+    if (!origin || isOriginAllowed(origin)) {
+      return callback(null, true);
+    }
+    return callback(new Error('Origin not allowed'), false);
+  },
+  credentials: true
+};
+
+app.use(cors(corsOptions));
+app.options('*', cors(corsOptions));
+app.use(express.json({ limit: '100kb' }));
+
+const rateLimitWindowMs = 60_000;
+const rateLimitMax = 30;
+const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
+
+app.get('/healthz', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/internal/broadcast', (req, res) => {
+  if (!internalToken) {
+    return res.status(404).json({ error: 'Not enabled' });
+  }
+
+  const headerToken = req.header('x-internal-token');
+  if (headerToken !== internalToken) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const limitKey = `${req.ip}`;
+  const now = Date.now();
+  const entry = rateLimitStore.get(limitKey);
+  if (entry && entry.resetAt > now) {
+    if (entry.count >= rateLimitMax) {
+      return res.status(429).json({ error: 'Rate limit exceeded' });
+    }
+    entry.count += 1;
+  } else {
+    rateLimitStore.set(limitKey, { count: 1, resetAt: now + rateLimitWindowMs });
+  }
+
+  const parsedBody = BroadcastPayloadSchema.safeParse(req.body ?? {});
+  if (!parsedBody.success) {
+    return res.status(400).json({ error: parsedBody.error.flatten() });
+  }
+
+  const { channel, payload } = parsedBody.data;
+  dispatchRedisEvent(channel, payload);
+  return res.json({ ok: true });
+});
+
+const server = http.createServer(app);
+
+const io = new Server(server, {
+  cors: {
+    origin(origin, callback) {
+      if (!origin || isOriginAllowed(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error('Origin not allowed'));
+    }
+  }
+});
+
+const redisOptions = {
+  host: redisHost,
+  port: redisPort,
+  retryStrategy: (times: number) => Math.min(times * 50, 2000)
+};
+
+const redisSubscriber = new Redis(redisOptions);
+
+redisSubscriber.on('ready', () => {
+  console.log('[redis] subscriber ready');
+});
+
+redisSubscriber.on('error', (err) => {
+  console.error('[redis] subscriber error', err);
+});
+
+redisSubscriber.psubscribe('game:*').catch((err) => {
+  console.error('[redis] failed to psubscribe', err);
+});
+
+redisSubscriber.on('pmessage', (_pattern, channel, message) => {
+  try {
+    const raw = JSON.parse(message);
+    const parsed = RedisEventSchema.safeParse(raw);
+    if (!parsed.success) {
+      console.warn('[redis] invalid payload', parsed.error.flatten());
+      return;
+    }
+    dispatchRedisEvent(channel, parsed.data);
+  } catch (err) {
+    console.error('[redis] failed to parse message', err);
+  }
+});
+
+type SocketData = {
+  room?: string;
+  userId?: number;
+  username?: string;
+  joined?: boolean;
+};
+
+const presence = new Map<string, Map<number, number>>();
+const leaveTimers = new Map<string, NodeJS.Timeout>();
+
+const eventMap: Record<RedisEvent['type'], string> = {
+  ROUND_START: 'round:start',
+  ROUND_SOLVED: 'round:solved',
+  SCORE_UPDATE: 'score:update',
+  PLAYER_JOINED: 'player:joined',
+  PLAYER_LEFT: 'player:left',
+  GAME_ENDED: 'game:ended'
+};
+
+function presenceKey(room: string, userId: number) {
+  return `${room}:${userId}`;
+}
+
+function cancelLeave(room: string, userId: number) {
+  const key = presenceKey(room, userId);
+  const timer = leaveTimers.get(key);
+  if (timer) {
+    clearTimeout(timer);
+    leaveTimers.delete(key);
+  }
+}
+
+function scheduleLeave(room: string, userId: number) {
+  const key = presenceKey(room, userId);
+  if (leaveTimers.has(key)) {
+    return;
+  }
+  const timer = setTimeout(() => {
+    leaveTimers.delete(key);
+    const roomPresence = presence.get(room);
+    if (roomPresence && roomPresence.get(userId)) {
+      return;
+    }
+    const namespace = io.of('/game');
+    namespace.to(room).emit('player:left', { userId });
+    console.log(`[socket] user ${userId} left ${room}`);
+  }, 2000);
+  leaveTimers.set(key, timer);
+}
+
+function incrementPresence(room: string, userId: number) {
+  const roomPresence = presence.get(room) ?? new Map<number, number>();
+  const count = (roomPresence.get(userId) ?? 0) + 1;
+  roomPresence.set(userId, count);
+  presence.set(room, roomPresence);
+  cancelLeave(room, userId);
+}
+
+function decrementPresence(room: string, userId: number) {
+  const roomPresence = presence.get(room);
+  if (!roomPresence) {
+    return;
+  }
+  const count = roomPresence.get(userId) ?? 0;
+  if (count <= 1) {
+    roomPresence.delete(userId);
+    if (roomPresence.size === 0) {
+      presence.delete(room);
+    }
+    scheduleLeave(room, userId);
+  } else {
+    roomPresence.set(userId, count - 1);
+  }
+}
+
+function isOriginAllowed(origin: string) {
+  if (allowAnyOrigin) {
+    return true;
+  }
+  return allowedOriginSet.has(origin);
+}
+
+function verifyHelloToken(payload: HelloPayload) {
+  if (!payload.token) {
+    return true;
+  }
+  if (!hmacSecret) {
+    console.warn('[auth] token provided but REALTIME_HMAC_SECRET is not configured');
+    return false;
+  }
+  try {
+    const expected = crypto.createHmac('sha256', hmacSecret).update(`${payload.userId}.${payload.username}`).digest('hex');
+    const received = payload.token;
+    if (expected.length !== received.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(Buffer.from(expected, 'utf8'), Buffer.from(received, 'utf8'));
+  } catch (err) {
+    console.error('[auth] failed to verify token', err);
+    return false;
+  }
+}
+
+function dispatchRedisEvent(channel: string, event: RedisEvent) {
+  const namespace = io.of('/game');
+  const eventName = eventMap[event.type];
+  if (!eventName) {
+    console.warn('[redis] unknown event type', event.type);
+    return;
+  }
+  const room = channel.startsWith('game:') ? channel : null;
+  if (!room) {
+    console.warn('[redis] unsupported channel', channel);
+    return;
+  }
+  namespace.to(room).emit(eventName, event);
+  console.log(`[redis] ${channel} -> ${eventName}`);
+}
+
+const gameNamespace = io.of('/game');
+
+gameNamespace.on('connection', (socket: Socket) => {
+  console.log('[socket] connection', socket.id, socket.handshake.address);
+  const originHeader = socket.handshake.headers.origin as string | undefined;
+  if (originHeader && !isOriginAllowed(originHeader)) {
+    console.warn('[socket] rejected origin', originHeader);
+    socket.disconnect(true);
+    return;
+  }
+
+  const queryPayload = HelloPayloadSchema.safeParse(flattenQuery(socket.handshake.query));
+  if (queryPayload.success) {
+    handleHello(socket, queryPayload.data);
+  }
+
+  socket.on('hello', (raw) => {
+    if ((socket.data as SocketData).joined) {
+      return;
+    }
+    const parsed = HelloPayloadSchema.safeParse(raw ?? {});
+    if (!parsed.success) {
+      socket.emit('hello:error', { message: 'INVALID_PAYLOAD', details: parsed.error.flatten() });
+      return;
+    }
+    handleHello(socket, parsed.data);
+  });
+
+  socket.on('disconnect', () => {
+    const data = socket.data as SocketData;
+    if (!data.joined || !data.room || !data.userId) {
+      return;
+    }
+    decrementPresence(data.room, data.userId);
+  });
+});
+
+function handleHello(socket: Socket, payload: HelloPayload) {
+  if (!verifyHelloToken(payload)) {
+    socket.emit('hello:error', { message: 'INVALID_TOKEN' });
+    socket.disconnect(true);
+    return;
+  }
+  const room = `game:${payload.gameId}`;
+  incrementPresence(room, payload.userId);
+  Promise.resolve(socket.join(room)).catch((err: unknown) =>
+    console.error('[socket] failed to join room', err)
+  );
+  const data = socket.data as SocketData;
+  data.joined = true;
+  data.room = room;
+  data.userId = payload.userId;
+  data.username = payload.username;
+  gameNamespace.to(room).emit('player:joined', { userId: payload.userId, username: payload.username });
+  console.log(`[socket] user ${payload.userId} joined ${room}`);
+}
+
+server.listen(realtimePort, () => {
+  console.log(`[server] realtime service listening on port ${realtimePort}`);
+});
+
+process.on('unhandledRejection', (err) => {
+  console.error('[process] unhandledRejection', err);
+});
+
+process.on('uncaughtException', (err) => {
+  console.error('[process] uncaughtException', err);
+});
+
+process.on('SIGTERM', () => {
+  console.log('[process] received SIGTERM, shutting down');
+  server.close(() => process.exit(0));
+  io.close();
+  redisSubscriber.quit().catch(() => undefined);
+});
+
+process.on('SIGINT', () => {
+  console.log('[process] received SIGINT, shutting down');
+  server.close(() => process.exit(0));
+  io.close();
+  redisSubscriber.quit().catch(() => undefined);
+});
+
+function flattenQuery(query: Record<string, unknown>) {
+  const flattened: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(query)) {
+    if (Array.isArray(value)) {
+      flattened[key] = value[0];
+    } else {
+      flattened[key] = value;
+    }
+  }
+  return flattened;
+}

--- a/apps/realtime-node/src/types.ts
+++ b/apps/realtime-node/src/types.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const HelloPayloadSchema = z.object({
+  gameId: z.coerce.number().int().positive(),
+  userId: z.coerce.number().int().positive(),
+  username: z.string().min(1).max(128),
+  token: z.string().min(1).optional()
+});
+
+export type HelloPayload = z.infer<typeof HelloPayloadSchema>;
+
+export const RedisEventSchema = z
+  .object({
+    type: z.enum([
+      'ROUND_START',
+      'ROUND_SOLVED',
+      'SCORE_UPDATE',
+      'PLAYER_JOINED',
+      'PLAYER_LEFT',
+      'GAME_ENDED'
+    ])
+  })
+  .passthrough();
+
+export type RedisEvent = z.infer<typeof RedisEventSchema>;
+
+export const BroadcastPayloadSchema = z.object({
+  channel: z.string().min(1),
+  payload: RedisEventSchema
+});
+
+export type BroadcastPayload = z.infer<typeof BroadcastPayloadSchema>;

--- a/apps/realtime-node/tsconfig.json
+++ b/apps/realtime-node/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MelodyQuest</title>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "melodyquest-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,29 @@
+function App() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center text-center gap-6">
+      <h1 className="text-5xl font-bold tracking-tight">MelodyQuest</h1>
+      <p className="max-w-xl text-lg text-slate-300">
+        Embark on a musical adventure. This placeholder interface will soon guide players through quests,
+        challenges, and realtime battles synchronized with the MelodyQuest universe.
+      </p>
+      <div className="flex gap-4">
+        <a
+          className="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-600 transition"
+          href="/api/health"
+          target="_blank"
+          rel="noreferrer"
+        >
+          API Health
+        </a>
+        <a
+          className="px-4 py-2 rounded border border-indigo-400 text-indigo-200 hover:bg-indigo-500/10 transition"
+          href="#"
+        >
+          Coming Soon
+        </a>
+      </div>
+    </main>
+  );
+}
+
+export default App;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+body {
+  margin: 0;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 5173
+  },
+  build: {
+    outDir: 'dist'
+  }
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,139 @@
+version: '3.9'
+
+services:
+  nginx:
+    image: nginx:1.25-alpine
+    depends_on:
+      web:
+        condition: service_completed_successfully
+      php:
+        condition: service_healthy
+      realtime:
+        condition: service_started
+    ports:
+      - "80:80"
+    volumes:
+      - web_build:/usr/share/nginx/html:ro
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      - melodyquest_net
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  web:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - ./apps/web:/app
+      - web_node_modules:/app/node_modules
+      - web_build:/app/dist
+    command: sh -c "npm install && npm run build"
+    environment:
+      - NODE_ENV=production
+    networks:
+      - melodyquest_net
+    healthcheck:
+      test: ["CMD", "node", "-e", "process.exit(0)"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  php:
+    build:
+      context: ./apps/api-php
+      dockerfile: Dockerfile
+    volumes:
+      - ./apps/api-php:/var/www/api
+      - /var/www/api/vendor
+    environment:
+      - APP_ENV=development
+      - DB_HOST=mysql
+      - DB_PORT=3306
+      - DB_DATABASE=${DB_DATABASE}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+    networks:
+      melodyquest_net:
+        aliases:
+          - php-fpm
+    depends_on:
+      mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "php", "-m"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  mysql:
+    image: mysql:8.3
+    environment:
+      - MYSQL_ROOT_PASSWORD=${DB_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${DB_DATABASE}
+      - MYSQL_USER=${DB_USERNAME}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./infra/db-init:/docker-entrypoint-initdb.d
+    command: ["mysqld", "--character-set-server=utf16", "--collation-server=utf16_general_ci"]
+    networks:
+      - melodyquest_net
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    volumes:
+      - redis_data:/data
+      - ./infra/redis/redis.conf:/usr/local/etc/redis/redis.conf:ro
+    networks:
+      - melodyquest_net
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  realtime:
+    build:
+      context: ./apps/realtime-node
+      dockerfile: Dockerfile
+    environment:
+      - APP_ENV=${APP_ENV:-development}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-*}
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
+      - REALTIME_PORT=3000
+      - REALTIME_HMAC_SECRET=${REALTIME_HMAC_SECRET}
+      - ADMIN_TOKEN=${ADMIN_TOKEN}
+    ports:
+      - "3000:3000"
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - melodyquest_net
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+networks:
+  melodyquest_net:
+    driver: bridge
+
+volumes:
+  mysql_data:
+  redis_data:
+  web_node_modules:
+  web_build:

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,53 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api {
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
+
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME /var/www/api/public/index.php;
+        fastcgi_param SCRIPT_NAME /index.php;
+        fastcgi_param DOCUMENT_ROOT /var/www/api/public;
+        fastcgi_param PATH_INFO $uri;
+        fastcgi_param REQUEST_URI $request_uri;
+        fastcgi_pass php-fpm:9000;
+    }
+
+    location /socket.io/ {
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
+
+        if ($request_method = OPTIONS) {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
+            return 204;
+        }
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_pass http://realtime:3000/socket.io/;
+    }
+}

--- a/infra/db-init/01_schema.sql
+++ b/infra/db-init/01_schema.sql
@@ -1,0 +1,172 @@
+CREATE DATABASE IF NOT EXISTS melodyquest
+  CHARACTER SET utf16
+  COLLATE utf16_general_ci;
+
+USE melodyquest;
+
+CREATE TABLE IF NOT EXISTS users (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  username VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_general_ci NOT NULL UNIQUE,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE = InnoDB DEFAULT CHARSET = utf16 COLLATE = utf16_general_ci;
+
+CREATE TABLE IF NOT EXISTS categories (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(128) CHARACTER SET utf16 COLLATE utf16_general_ci NOT NULL UNIQUE,
+  is_active TINYINT(1) NOT NULL DEFAULT 1
+) ENGINE = InnoDB DEFAULT CHARSET = utf16 COLLATE = utf16_general_ci;
+
+CREATE TABLE IF NOT EXISTS tracks (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  youtube_url VARCHAR(255) CHARACTER SET utf16 COLLATE utf16_general_ci NOT NULL,
+  youtube_video_id VARCHAR(16) CHARACTER SET utf16 COLLATE utf16_general_ci NOT NULL,
+  category_id BIGINT NOT NULL,
+  title VARCHAR(255) CHARACTER SET utf16 COLLATE utf16_general_ci NULL,
+  cover_image_url VARCHAR(255) CHARACTER SET utf16 COLLATE utf16_general_ci NULL,
+  created_by BIGINT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_tracks_category_id (category_id),
+  CONSTRAINT fk_tracks_category FOREIGN KEY (category_id) REFERENCES categories(id),
+  CONSTRAINT fk_tracks_created_by FOREIGN KEY (created_by) REFERENCES users(id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf16 COLLATE = utf16_general_ci;
+
+CREATE TABLE IF NOT EXISTS track_answers (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  track_id BIGINT NOT NULL,
+  answer_text VARCHAR(255) CHARACTER SET utf16 COLLATE utf16_general_ci NOT NULL,
+  normalized VARBINARY(255) NOT NULL,
+  CONSTRAINT uq_track_answers UNIQUE (track_id, normalized),
+  CONSTRAINT fk_track_answers_track FOREIGN KEY (track_id) REFERENCES tracks(id),
+  INDEX idx_track_answers_norm (normalized(191))
+) ENGINE = InnoDB DEFAULT CHARSET = utf16 COLLATE = utf16_general_ci;
+
+CREATE TABLE IF NOT EXISTS games (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  host_user_id BIGINT NOT NULL,
+  status ENUM('LOBBY', 'RUNNING', 'ENDED') NOT NULL DEFAULT 'LOBBY',
+  round_count INT NOT NULL DEFAULT 10,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  started_at TIMESTAMP NULL,
+  ended_at TIMESTAMP NULL,
+  CONSTRAINT fk_games_host FOREIGN KEY (host_user_id) REFERENCES users(id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf16 COLLATE = utf16_general_ci;
+
+CREATE TABLE IF NOT EXISTS game_categories (
+  game_id BIGINT NOT NULL,
+  category_id BIGINT NOT NULL,
+  PRIMARY KEY (game_id, category_id),
+  CONSTRAINT fk_gc_game FOREIGN KEY (game_id) REFERENCES games(id),
+  CONSTRAINT fk_gc_category FOREIGN KEY (category_id) REFERENCES categories(id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf16 COLLATE = utf16_general_ci;
+
+CREATE TABLE IF NOT EXISTS game_players (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  game_id BIGINT NOT NULL,
+  user_id BIGINT NOT NULL,
+  joined_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_game_user (game_id, user_id),
+  CONSTRAINT fk_gp_game FOREIGN KEY (game_id) REFERENCES games(id),
+  CONSTRAINT fk_gp_user FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf16 COLLATE = utf16_general_ci;
+
+CREATE TABLE IF NOT EXISTS rounds (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  game_id BIGINT NOT NULL,
+  round_number INT NOT NULL,
+  track_id BIGINT NOT NULL,
+  started_at TIMESTAMP NULL,
+  ended_at TIMESTAMP NULL,
+  winner_user_id BIGINT NULL,
+  reveal_video TINYINT(1) NOT NULL DEFAULT 0,
+  UNIQUE KEY uq_game_round (game_id, round_number),
+  CONSTRAINT fk_rounds_game FOREIGN KEY (game_id) REFERENCES games(id),
+  CONSTRAINT fk_rounds_track FOREIGN KEY (track_id) REFERENCES tracks(id),
+  CONSTRAINT fk_rounds_winner FOREIGN KEY (winner_user_id) REFERENCES users(id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf16 COLLATE = utf16_general_ci;
+
+CREATE TABLE IF NOT EXISTS guesses (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  round_id BIGINT NOT NULL,
+  user_id BIGINT NOT NULL,
+  guess_text VARCHAR(255) CHARACTER SET utf16 COLLATE utf16_general_ci NOT NULL,
+  normalized VARBINARY(255) NOT NULL,
+  is_correct TINYINT(1) NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_guesses_round (round_id),
+  INDEX idx_guesses_user (user_id),
+  INDEX idx_guesses_norm (normalized(191)),
+  CONSTRAINT fk_guesses_round FOREIGN KEY (round_id) REFERENCES rounds(id),
+  CONSTRAINT fk_guesses_user FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf16 COLLATE = utf16_general_ci;
+
+CREATE TABLE IF NOT EXISTS scores (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  game_id BIGINT NOT NULL,
+  user_id BIGINT NOT NULL,
+  points INT NOT NULL DEFAULT 0,
+  UNIQUE KEY uq_score (game_id, user_id),
+  CONSTRAINT fk_scores_game FOREIGN KEY (game_id) REFERENCES games(id),
+  CONSTRAINT fk_scores_user FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf16 COLLATE = utf16_general_ci;
+
+DROP FUNCTION IF EXISTS fn_normalize;
+DELIMITER $$
+CREATE FUNCTION fn_normalize(s TEXT CHARSET utf16) RETURNS VARBINARY(255)
+  DETERMINISTIC
+BEGIN
+  SET s = LOWER(s);
+  SET s = REPLACE(REPLACE(REPLACE(REPLACE(s, 'à', 'a'), 'á', 'a'), 'â', 'a'), 'ä', 'a');
+  SET s = REPLACE(REPLACE(REPLACE(REPLACE(s, 'é', 'e'), 'è', 'e'), 'ê', 'e'), 'ë', 'e');
+  SET s = REPLACE(REPLACE(REPLACE(REPLACE(s, 'ì', 'i'), 'í', 'i'), 'î', 'i'), 'ï', 'i');
+  SET s = REPLACE(REPLACE(REPLACE(REPLACE(s, 'ò', 'o'), 'ó', 'o'), 'ô', 'o'), 'ö', 'o');
+  SET s = REPLACE(REPLACE(REPLACE(REPLACE(s, 'ù', 'u'), 'ú', 'u'), 'û', 'u'), 'ü', 'u');
+  SET s = REPLACE(s, 'ç', 'c');
+  SET s = REPLACE(s, 'ñ', 'n');
+  SET s = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(s, '.', ' '), ',', ' '), '!', ' '), '?', ' '), ':', ' '), ';', ' ');
+  SET s = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(s, '-', ' '), '_', ' '), '/', ' '), '\\', ' '), '\'', ' ');
+  WHILE INSTR(s, '  ') > 0 DO
+    SET s = REPLACE(s, '  ', ' ');
+  END WHILE;
+  SET s = TRIM(s);
+  RETURN CAST(LEFT(s, 255) AS VARBINARY(255));
+END$$
+DELIMITER ;
+
+DROP TRIGGER IF EXISTS trg_track_answers_bi;
+DELIMITER $$
+CREATE TRIGGER trg_track_answers_bi BEFORE INSERT ON track_answers
+FOR EACH ROW
+BEGIN
+  SET NEW.normalized = fn_normalize(NEW.answer_text);
+END$$
+DELIMITER ;
+
+DROP TRIGGER IF EXISTS trg_track_answers_bu;
+DELIMITER $$
+CREATE TRIGGER trg_track_answers_bu BEFORE UPDATE ON track_answers
+FOR EACH ROW
+BEGIN
+  SET NEW.normalized = fn_normalize(NEW.answer_text);
+END$$
+DELIMITER ;
+
+DROP TRIGGER IF EXISTS trg_guesses_bi;
+DELIMITER $$
+CREATE TRIGGER trg_guesses_bi BEFORE INSERT ON guesses
+FOR EACH ROW
+BEGIN
+  SET NEW.normalized = fn_normalize(NEW.guess_text);
+END$$
+DELIMITER ;
+
+DROP TRIGGER IF EXISTS trg_guesses_bu;
+DELIMITER $$
+CREATE TRIGGER trg_guesses_bu BEFORE UPDATE ON guesses
+FOR EACH ROW
+BEGIN
+  SET NEW.normalized = fn_normalize(NEW.guess_text);
+END$$
+DELIMITER ;
+
+-- Les champs “normalized” en VARBINARY permettent l'indexation stable malgré l'UTF-16.
+-- Les longueurs d'index (191) assurent la compatibilité avec innodb_large_prefix off/on.

--- a/infra/redis/redis.conf
+++ b/infra/redis/redis.conf
@@ -1,0 +1,4 @@
+bind 0.0.0.0
+protected-mode no
+port 6379
+appendonly yes


### PR DESCRIPTION
## Summary
- replace the previous JavaScript stub with a TypeScript Socket.IO gateway that validates clients, relays Redis events, and exposes health/debug endpoints
- add build tooling, Dockerfile, and documentation for the realtime service while wiring docker-compose to build the new image

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e398735610833090d30b2439c22b99